### PR TITLE
add parallel make, unit tests to openexr autoconf build

### DIFF
--- a/jjb/openexr/shell/build-ilmbase.sh
+++ b/jjb/openexr/shell/build-ilmbase.sh
@@ -29,7 +29,13 @@ set -eux -o pipefail
 cd IlmBase || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-make
+OS=`uname`
+if [[ "$OS" == "Linux" ]]; then
+  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+else
+  NPROC=1
+fi
+make -j${NPROC}
 make install
 
 mkdir -p "$WORKSPACE/dist"

--- a/jjb/openexr/shell/build-ilmbase.sh
+++ b/jjb/openexr/shell/build-ilmbase.sh
@@ -29,9 +29,9 @@ set -eux -o pipefail
 cd IlmBase || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-OS=`uname`
+OS=$(uname)
 if [[ "$OS" == "Linux" ]]; then
-  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+  NPROC=$(cat /proc/cpuinfo|grep processor|wc -l)
 else
   NPROC=1
 fi

--- a/jjb/openexr/shell/build-ilmbase.sh
+++ b/jjb/openexr/shell/build-ilmbase.sh
@@ -35,8 +35,11 @@ if [[ "$OS" == "Linux" ]]; then
 else
   NPROC=1
 fi
-make -j${NPROC}
-make install
+make -j${NPROC} || exit 1
+echo "Running tests..."
+make -j${NPROC} check || exit 1
+echo "Installing..."
+make install || exit 1
 
 mkdir -p "$WORKSPACE/dist"
 tar -cJvf "$WORKSPACE/dist/ilmbase.tar.xz" -C "$PREFIX" .

--- a/jjb/openexr/shell/build-openexr-viewers.sh
+++ b/jjb/openexr/shell/build-openexr-viewers.sh
@@ -29,9 +29,9 @@ set -eux -o pipefail
 cd OpenEXR_Viewers || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-OS=`uname`
+OS=$(uname)
 if [[ "$OS" == "Linux" ]]; then
-  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+  NPROC=$(cat /proc/cpuinfo|grep processor|wc -l)
 else
   NPROC=1
 fi

--- a/jjb/openexr/shell/build-openexr-viewers.sh
+++ b/jjb/openexr/shell/build-openexr-viewers.sh
@@ -29,7 +29,13 @@ set -eux -o pipefail
 cd OpenEXR_Viewers || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-make
+OS=`uname`
+if [[ "$OS" == "Linux" ]]; then
+  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+else
+  NPROC=1
+fi
+make -j${NPROC}
 make install
 
 mkdir -p "$WORKSPACE/dist"

--- a/jjb/openexr/shell/build-openexr.sh
+++ b/jjb/openexr/shell/build-openexr.sh
@@ -29,7 +29,13 @@ set -eux -o pipefail
 cd OpenEXR || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-make
+OS=`uname`
+if [[ "$OS" == "Linux" ]]; then
+  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+else
+  NPROC=1
+fi
+make -j${NPROC}
 make install
 
 mkdir -p "$WORKSPACE/dist"

--- a/jjb/openexr/shell/build-openexr.sh
+++ b/jjb/openexr/shell/build-openexr.sh
@@ -35,8 +35,11 @@ if [[ "$OS" == "Linux" ]]; then
 else
   NPROC=1
 fi
-make -j${NPROC}
-make install
+make -j${NPROC} || exit 1
+echo "Running tests..."
+make -j${NPROC} check || exit 1
+echo "Installing..."
+make install || exit 1
 
 mkdir -p "$WORKSPACE/dist"
 tar -cJvf "$WORKSPACE/dist/openexr.tar.xz" -C "$PREFIX" .

--- a/jjb/openexr/shell/build-openexr.sh
+++ b/jjb/openexr/shell/build-openexr.sh
@@ -29,9 +29,9 @@ set -eux -o pipefail
 cd OpenEXR || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-OS=`uname`
+OS=$(uname)
 if [[ "$OS" == "Linux" ]]; then
-  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+  NPROC=$(cat /proc/cpuinfo|grep processor|wc -l)
 else
   NPROC=1
 fi

--- a/jjb/openexr/shell/build-pyilmbase.sh
+++ b/jjb/openexr/shell/build-pyilmbase.sh
@@ -34,7 +34,13 @@ set -eux -o pipefail
 cd PyIlmBase || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-make
+OS=`uname`
+if [[ "$OS" == "Linux" ]]; then
+  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+else
+  NPROC=1
+fi
+make -j${NPROC}
 make install
 
 mkdir -p "$WORKSPACE/dist"

--- a/jjb/openexr/shell/build-pyilmbase.sh
+++ b/jjb/openexr/shell/build-pyilmbase.sh
@@ -34,9 +34,9 @@ set -eux -o pipefail
 cd PyIlmBase || exit
 ./bootstrap
 ./configure --prefix="$PREFIX"
-OS=`uname`
+OS=$(uname)
 if [[ "$OS" == "Linux" ]]; then
-  NPROC=`cat /proc/cpuinfo|grep processor|wc -l`
+  NPROC=$(cat /proc/cpuinfo|grep processor|wc -l)
 else
   NPROC=1
 fi


### PR DESCRIPTION
This, at least under linux, will query the number of active cores and
run make using that number of processors.

Signed-off-by: Kimball Thurston <kdt3rd@gmail.com>