### PR TITLE
Set builder to an existing builder

### DIFF
--- a/jjb/opencolorio/opencolorio.yaml
+++ b/jjb/opencolorio/opencolorio.yaml
@@ -9,7 +9,7 @@
     branch: master
     project: opencolorio
     project-name: opencolorio
-    build-node: ubuntu1604-builder-2c-1g
+    build-node: ubuntu1604-builder-2c-2g
 
     mvn-settings: opencolorio-settings
     make-opts: '-j8'


### PR DESCRIPTION
The previous builder was removed from the system so change it to
one that exists.
