### PR TITLE
Added new vfx-2018 builder config for jenkins

### DIFF
--- a/jenkins-config/clouds/openstack/cattle/centos7-builder-vfx-2018-2c-1g.cfg
+++ b/jenkins-config/clouds/openstack/cattle/centos7-builder-vfx-2018-2c-1g.cfg
@@ -1,0 +1,2 @@
+IMAGE_NAME=ZZCI - CentOS 7 - builder-vfx-2018 - x86_64 - 20181204-102219.360
+HARDWARE_ID=v1-standard-1


### PR DESCRIPTION
This is to enable the image built by https://jenkins.aswf.io/sandbox/job/ci-management-packer-merge-centos-7-builder-vfx-2018/1/console
"ZZCI - CentOS 7 - builder-vfx-2018 - x86_64 - 20181204-102219.360"