### PR TITLE
Added boost, tbb, ilmbase, pyilmbase and openexr docker builder jobs

### DIFF
--- a/jjb/3rdparty/.gitignore
+++ b/jjb/3rdparty/.gitignore
@@ -1,0 +1,3 @@
+*.tar.gz
+*.tar.bz2
+*.zip

--- a/jjb/3rdparty/3rdparty.yaml
+++ b/jjb/3rdparty/3rdparty.yaml
@@ -1,23 +1,53 @@
 ---
 - project:
     name: 3rdparty-boost-vfx2018
+    3rdparty-project: boost
     jobs:
       - '3rdparty-{3rdparty-project}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
     stream: vfx2018
-    3rdparty-project: boost
 
 - project:
     name: 3rdparty-tbb-vfx2018
+    3rdparty-project: tbb
     jobs:
       - '3rdparty-{3rdparty-project}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
     stream: vfx2018
-    3rdparty-project: tbb
+
+- project:
+    name: 3rdparty-ilmbase-vfx2018
+    3rdparty-project: ilmbase
+    jobs:
+      - '3rdparty-{3rdparty-project}-stage-{stream}'
+    project: ci-management
+    project-name: ci-management
+    build-node: ubuntu1604-builder-docker-2c-2g
+    stream: vfx2018
+
+- project:
+    name: 3rdparty-openexr-vfx2018
+    3rdparty-project: openexr
+    jobs:
+      - '3rdparty-{3rdparty-project}-stage-{stream}'
+    project: ci-management
+    project-name: ci-management
+    build-node: ubuntu1604-builder-docker-2c-2g
+    stream: vfx2018
+
+- project:
+    name: 3rdparty-pyilmbase-vfx2018
+    3rdparty-project: pyilmbase
+    jobs:
+      - '3rdparty-{3rdparty-project}-stage-{stream}'
+    project: ci-management
+    project-name: ci-management
+    build-node: ubuntu1604-builder-docker-2c-2g
+    stream: vfx2018
 
 - job-template:
     name: '3rdparty-{3rdparty-project}-stage-{stream}'
@@ -89,6 +119,7 @@
 
     builders:
       - shell: 'pip install --user lftools'
+      - shell: !include-raw-escape: boost/download.sh
       - shell: 'cd jjb/3rdparty/{3rdparty-project} && docker build -t {3rdparty-project}-builder .'
       - shell: 'mkdir -p $WORKSPACE/dist'
       - shell: 'docker run --name {3rdparty-project}-builder --rm -v $WORKSPACE/dist:/mnt/dist {3rdparty-project}-builder'

--- a/jjb/3rdparty/3rdparty.yaml
+++ b/jjb/3rdparty/3rdparty.yaml
@@ -2,6 +2,7 @@
 - project:
     name: 3rdparty-boost-vfx2018
     3rdparty: boost
+    download: !include-raw-escape: boost/download.sh
     jobs:
       - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
@@ -12,6 +13,7 @@
 - project:
     name: 3rdparty-tbb-vfx2018
     3rdparty: tbb
+    download: !include-raw-escape: tbb/download.sh
     jobs:
       - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
@@ -22,6 +24,7 @@
 - project:
     name: 3rdparty-ilmbase-vfx2018
     3rdparty: ilmbase
+    download: !include-raw-escape: ilmbase/download.sh
     jobs:
       - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
@@ -32,6 +35,7 @@
 - project:
     name: 3rdparty-openexr-vfx2018
     3rdparty: openexr
+    download: !include-raw-escape: openexr/download.sh
     jobs:
       - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
@@ -42,6 +46,7 @@
 - project:
     name: 3rdparty-pyilmbase-vfx2018
     3rdparty: pyilmbase
+    download: !include-raw-escape: pyilmbase/download.sh
     jobs:
       - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
@@ -63,7 +68,7 @@
     cmake-opts: ''
     install-prefix: '$BUILD_DIR/output'
     make-opts: ''
-    pre-build: ''
+    download: ''
     stream: master
     submodule-recursive: true
     submodule-timeout: 10
@@ -119,7 +124,7 @@
 
     builders:
       - shell: 'pip install --user lftools'
-      - shell: !include-raw-escape: boost/download.sh
+      - shell: '{download}'
       - shell: 'cd jjb/3rdparty/{3rdparty} && docker build -t {3rdparty}-builder .'
       - shell: 'mkdir -p $WORKSPACE/dist'
       - shell: 'docker run --name {3rdparty}-builder --rm -v $WORKSPACE/dist:/mnt/dist {3rdparty}-builder'

--- a/jjb/3rdparty/3rdparty.yaml
+++ b/jjb/3rdparty/3rdparty.yaml
@@ -1,17 +1,26 @@
 ---
 - project:
-    name: 3rdparty-vfx2018
+    name: 3rdparty-boost-vfx2018
     jobs:
-      - '3rdparty-boost-stage-{stream}'
+      - '3rdparty-{3rdparty-project}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
     stream: vfx2018
-    nexus-group-id: io.aswf.3rdparty
-    staging-profile-id: 126694cb53ec54
+    3rdparty-project: boost
+
+- project:
+    name: 3rdparty-tbb-vfx2018
+    jobs:
+      - '3rdparty-{3rdparty-project}-stage-{stream}'
+    project: ci-management
+    project-name: ci-management
+    build-node: ubuntu1604-builder-docker-2c-2g
+    stream: vfx2018
+    3rdparty-project: tbb
 
 - job-template:
-    name: '3rdparty-boost-stage-{stream}'
+    name: '3rdparty-{3rdparty-project}-stage-{stream}'
 
     ######################
     # Default parameters #
@@ -80,8 +89,8 @@
 
     builders:
       - shell: 'pip install --user lftools'
-      - shell: 'cd jjb/3rdparty/boost && docker build -t boost-builder .'
+      - shell: 'cd jjb/3rdparty/{3rdparty-project} && docker build -t {3rdparty-project}-builder .'
       - shell: 'mkdir -p $WORKSPACE/dist'
-      - shell: 'docker run --name boost-builder --rm -v $WORKSPACE/dist:/mnt/dist boost-builder'
+      - shell: 'docker run --name {3rdparty-project}-builder --rm -v $WORKSPACE/dist:/mnt/dist {3rdparty-project}-builder'
     publishers:
       - lf-infra-publish

--- a/jjb/3rdparty/3rdparty.yaml
+++ b/jjb/3rdparty/3rdparty.yaml
@@ -1,9 +1,9 @@
 ---
 - project:
     name: 3rdparty-boost-vfx2018
-    3rdparty-project: boost
+    3rdparty: boost
     jobs:
-      - '3rdparty-{3rdparty-project}-stage-{stream}'
+      - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
@@ -11,9 +11,9 @@
 
 - project:
     name: 3rdparty-tbb-vfx2018
-    3rdparty-project: tbb
+    3rdparty: tbb
     jobs:
-      - '3rdparty-{3rdparty-project}-stage-{stream}'
+      - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
@@ -21,9 +21,9 @@
 
 - project:
     name: 3rdparty-ilmbase-vfx2018
-    3rdparty-project: ilmbase
+    3rdparty: ilmbase
     jobs:
-      - '3rdparty-{3rdparty-project}-stage-{stream}'
+      - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
@@ -31,9 +31,9 @@
 
 - project:
     name: 3rdparty-openexr-vfx2018
-    3rdparty-project: openexr
+    3rdparty: openexr
     jobs:
-      - '3rdparty-{3rdparty-project}-stage-{stream}'
+      - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
@@ -41,16 +41,16 @@
 
 - project:
     name: 3rdparty-pyilmbase-vfx2018
-    3rdparty-project: pyilmbase
+    3rdparty: pyilmbase
     jobs:
-      - '3rdparty-{3rdparty-project}-stage-{stream}'
+      - '3rdparty-{3rdparty}-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
     stream: vfx2018
 
 - job-template:
-    name: '3rdparty-{3rdparty-project}-stage-{stream}'
+    name: '3rdparty-{3rdparty}-stage-{stream}'
 
     ######################
     # Default parameters #
@@ -120,8 +120,8 @@
     builders:
       - shell: 'pip install --user lftools'
       - shell: !include-raw-escape: boost/download.sh
-      - shell: 'cd jjb/3rdparty/{3rdparty-project} && docker build -t {3rdparty-project}-builder .'
+      - shell: 'cd jjb/3rdparty/{3rdparty} && docker build -t {3rdparty}-builder .'
       - shell: 'mkdir -p $WORKSPACE/dist'
-      - shell: 'docker run --name {3rdparty-project}-builder --rm -v $WORKSPACE/dist:/mnt/dist {3rdparty-project}-builder'
+      - shell: 'docker run --name {3rdparty}-builder --rm -v $WORKSPACE/dist:/mnt/dist {3rdparty}-builder'
     publishers:
       - lf-infra-publish

--- a/jjb/3rdparty/README.md
+++ b/jjb/3rdparty/README.md
@@ -4,15 +4,46 @@ This set of jenkins jobs build binaries for VFX Platform packages that are requi
 
 All builds are based on a minimal VFX Platform compliant docker image.
 
+## Package Layout
 
-### Jenkins Jobs
+The layout of installed packages looks like this:
+```
+/opt/aswf/
+`-- vfx2018
+    |-- boost
+    |   |-- include
+    |   `-- lib
+    |-- ilmbase
+    |   |-- include
+    |   `-- lib
+    |-- openexr
+    |   |-- bin
+    |   |-- include
+    |   |-- lib
+    |   `-- share
+    |-- pyilmbase
+    |   |-- include
+    |   |-- lib
+    |   |-- lib64
+    |   `-- share
+    `-- tbb
+        |-- include
+        `-- lib
+```
+When building or using these packages the `LD_LIBRARY_PATH` and `PYTHONPATH` environment variables must be set accordingly, see the `all/Dockerfile` file for an example.
+
+## Jenkins Jobs
 
 All jobs are named 3rdparty-X-vfx2018 where X is a third-party package for which we need binaries available.
 
 Use the regular `jenkins-jobs update jjb/` script to upload the jobs to the jenkins sandbox.
 
 
-### Local testing
+## Local testing
 
 In order to test these docker builds locally the `build_local.py` script can be used to build all 3rdparty packages in the right order
 and with the right dependencies, the only requirement is a linux machine with docker installed.
+
+When running locally, an extra docker image is built called `all` that brings in all previously built packages. This allows local inspection of 
+the built artifacts in a working environment and easier debugging.
+To inspect the all-builder image run this `docker run -it --rm --entrypoint bash all-builder`.

--- a/jjb/3rdparty/README.md
+++ b/jjb/3rdparty/README.md
@@ -1,0 +1,18 @@
+# Third Party Packages
+
+This set of jenkins jobs build binaries for VFX Platform packages that are required to build ASWF packages.
+
+All builds are based on a minimal VFX Platform compliant docker image.
+
+
+### Jenkins Jobs
+
+All jobs are named 3rdparty-X-vfx2018 where X is a third-party package for which we need binaries available.
+
+Use the regular `jenkins-jobs update jjb/` script to upload the jobs to the jenkins sandbox.
+
+
+### Local testing
+
+In order to test these docker builds locally the `build_local.py` script can be used to build all 3rdparty packages in the right order
+and with the right dependencies, the only requirement is a linux machine with docker installed.

--- a/jjb/3rdparty/all/Dockerfile
+++ b/jjb/3rdparty/all/Dockerfile
@@ -1,0 +1,35 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+ENV ASWF_BUILD_DIR /tmp/vfx-build
+ENV ASWF_ROOT_DIR /opt/aswf/vfx2018
+
+USER root
+
+RUN mkdir -p $ASWF_BUILD_DIR && \
+    mkdir -p $ASWF_ROOT_DIR
+
+# Common requirements
+RUN yum install -y which make bzip2
+
+# pyilmbase build requirements
+RUN yum install -y file python-devel zlib-devel
+
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" &&\
+    python get-pip.py &&\
+    pip install numpy==1.12.1
+
+# ilmbase and boost dependencies
+ADD ilmbase-2.2.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ADD boost-1.61.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ADD pyilmbase-2.2.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ADD openexr-2.2.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ADD tbb-2017.6-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+
+ENV PKG_CONFIG_PATH $ASWF_ROOT_DIR/ilmbase/lib/pkgconfig:$ASWF_ROOT_DIR/pyilmbase/lib/pkgconfig:$ASWF_ROOT_DIR/openexr/lib/pkgconfig
+ENV LD_LIBRARY_PATH $ASWF_ROOT_DIR/ilmbase/lib:$ASWF_ROOT_DIR/boost/lib:$ASWF_ROOT_DIR/pyilmbase/lib:$ASWF_ROOT_DIR/openexr/lib::$ASWF_ROOT_DIR/tbb/lib
+ENV PYTHONPATH $ASWF_ROOT_DIR/pyilmbase/lib
+
+# Generating the tarball as part of running the image.
+# Needs "-v `pwd`:/mnt/dist" while running
+WORKDIR $ASWF_ROOT_DIR
+ENTRYPOINT tar -cvjSf /mnt/dist/all-vfx-2018.tar.bz2 *

--- a/jjb/3rdparty/all/download.sh
+++ b/jjb/3rdparty/all/download.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'Nothing to download for now'

--- a/jjb/3rdparty/boost/Dockerfile
+++ b/jjb/3rdparty/boost/Dockerfile
@@ -1,25 +1,27 @@
 FROM centos/devtoolset-6-toolchain-centos7
 
-ENV ASWF_DIR /opt/aswf/vfx2018
-ENV TMP_DIR /tmp/vfx-build
-ENV DOWNLOADS_DIR /tmp/vfx-downloads
+ENV ASWF_BUILD_DIR /tmp/vfx-build
+ENV ASWF_ROOT_DIR /opt/aswf/vfx2018
 
 USER root
 
-RUN mkdir -p $TMP_DIR && \
-    mkdir -p $ASWF_DIR && \
-    mkdir -p $DOWNLOADS_DIR
+RUN mkdir -p $ASWF_BUILD_DIR && \
+    mkdir -p $ASWF_ROOT_DIR
 
-RUN yum install -y wget bzip2 which python-devel bzip2-devel
+# Common requirements
+RUN yum install -y which bzip2
 
-RUN wget https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.bz2/download -O $DOWNLOADS_DIR/boost_1_61_0.tar.bz2
+# Boost build requirements
+RUN yum install -y python-devel bzip2-devel
 
-RUN cd $TMP_DIR &&\
-    tar -jxf $DOWNLOADS_DIR/boost_1_61_0.tar.bz2 &&\
-    cd $TMP_DIR/boost_1_61_0 &&\
-    ./bootstrap.sh \
-        --prefix=$ASWF_DIR &&\
-    ./bjam \
+ADD boost_1_61_0.tar.bz2 $ASWF_BUILD_DIR
+
+WORKDIR $ASWF_BUILD_DIR/boost_1_61_0
+
+RUN ./bootstrap.sh \
+        --prefix=$ASWF_ROOT_DIR/boost
+
+RUN ./bjam \
         variant=release \
         link=shared \
         threading=multi \
@@ -27,7 +29,8 @@ RUN cd $TMP_DIR &&\
         linkflags="-std=c++14" \
         install
 
+
 # Generating the tarball as part of running the image.
 # Needs "-v `pwd`:/mnt/dist" while running
-ENTRYPOINT cd $ASWF_DIR &&\
-    tar -cvjSf /mnt/dist/boost-1.61.0-vfx-2018.tar.bz2 *
+WORKDIR $ASWF_ROOT_DIR
+ENTRYPOINT tar -cvjSf /mnt/dist/boost-1.61.0-vfx-2018.tar.bz2 boost

--- a/jjb/3rdparty/boost/Dockerfile
+++ b/jjb/3rdparty/boost/Dockerfile
@@ -1,0 +1,33 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+ENV ASWF_DIR /opt/aswf/vfx2018
+ENV TMP_DIR /tmp/vfx-build
+ENV DOWNLOADS_DIR /tmp/vfx-downloads
+
+USER root
+
+RUN mkdir -p $TMP_DIR && \
+    mkdir -p $ASWF_DIR && \
+    mkdir -p $DOWNLOADS_DIR
+
+RUN yum install -y wget bzip2 which python-devel bzip2-devel
+
+RUN wget https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.bz2/download -O $DOWNLOADS_DIR/boost_1_61_0.tar.bz2
+
+RUN cd $TMP_DIR &&\
+    tar -jxf $DOWNLOADS_DIR/boost_1_61_0.tar.bz2 &&\
+    cd $TMP_DIR/boost_1_61_0 &&\
+    ./bootstrap.sh \
+        --prefix=$ASWF_DIR &&\
+    ./bjam \
+        variant=release \
+        link=shared \
+        threading=multi \
+        cxxflags="-std=c++14" \
+        linkflags="-std=c++14" \
+        install
+
+# Generating the tarball as part of running the image.
+# Needs "-v `pwd`:/mnt/dist" while running
+ENTRYPOINT cd $ASWF_DIR &&\
+    tar -cvjSf /mnt/dist/boost-1.61.0-vfx-2018.tar.bz2 *

--- a/jjb/3rdparty/boost/boost.yaml
+++ b/jjb/3rdparty/boost/boost.yaml
@@ -1,18 +1,17 @@
 ---
 - project:
-    name: boost-docker
+    name: 3rdparty-vfx2018
     jobs:
-      - 'boost-docker-build'
+      - '3rdparty-boost-stage-{stream}'
     project: ci-management
     project-name: ci-management
     build-node: ubuntu1604-builder-docker-2c-2g
-
+    stream: vfx2018
     nexus-group-id: io.aswf.3rdparty
     staging-profile-id: 126694cb53ec54
 
 - job-template:
-    name: 'boost-docker-build'
-    id: boost-docker-build
+    name: '3rdparty-boost-stage-{stream}'
 
     ######################
     # Default parameters #

--- a/jjb/3rdparty/boost/boost.yaml
+++ b/jjb/3rdparty/boost/boost.yaml
@@ -1,0 +1,88 @@
+---
+- project:
+    name: boost-docker
+    jobs:
+      - 'boost-docker-build'
+    project: ci-management
+    project-name: ci-management
+    build-node: ubuntu1604-builder-docker-2c-2g
+
+    nexus-group-id: io.aswf.3rdparty
+    staging-profile-id: 126694cb53ec54
+
+- job-template:
+    name: 'boost-docker-build'
+    id: boost-docker-build
+
+    ######################
+    # Default parameters #
+    ######################
+
+    branch: master
+    build-days-to-keep: 7
+    build-dir: '$WORKSPACE/target'
+    build-timeout: 60
+    cmake-opts: ''
+    install-prefix: '$BUILD_DIR/output'
+    make-opts: ''
+    pre-build: ''
+    stream: master
+    submodule-recursive: true
+    submodule-timeout: 10
+    project: ci-management
+    project-name: ci-management
+
+    # github_included_regions MUST match gerrit_trigger_file_paths
+    github_included_regions:
+      - '.*'
+
+    #####################
+    # Job Configuration #
+    #####################
+
+    project-type: freestyle
+    node: '{build-node}'
+    concurrent: true
+
+    properties:
+      - lf-infra-properties:
+          build-days-to-keep: '{build-days-to-keep}'
+      - github:
+          url: '{git-url}/{github-org}/{project}'
+
+    scm:
+      - lf-infra-github-scm:
+          url: '{git-clone-url}{github-org}/{project}'
+          refspec: >
+              +refs/heads/*:refs/remotes/origin/*
+              +refs/pull/*:refs/remotes/origin/pr/*
+          branch: '$GERRIT_REFSPEC'
+          submodule-recursive: '{submodule-recursive}'
+          submodule-timeout: '{submodule-timeout}'
+          choosing-strategy: default
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+
+    parameters:
+      - lf-infra-parameters:
+          project: '{project}'
+          branch: '{branch}'
+          stream: '{stream}'
+          lftools-version: '{lftools-version}'
+      - lf-cmake-parameters:
+          build-dir: '{build-dir}'
+          cmake-opts: '{cmake-opts}'
+          install-prefix: '{install-prefix}'
+          make-opts: '{make-opts}'
+
+    wrappers:
+      - lf-infra-wrappers:
+          build-timeout: '{build-timeout}'
+          jenkins-ssh-credential: '{jenkins-ssh-credential}'
+
+    builders:
+      - shell: 'pip install --user lftools'
+      - shell: 'cd jjb/3rdparty/boost && docker build -t boost-builder .'
+      - shell: 'mkdir -p $WORKSPACE/dist'
+      - shell: 'docker run --name boost-builder --rm -v $WORKSPACE/dist:/mnt/dist boost-builder'
+    publishers:
+      - lf-infra-publish

--- a/jjb/3rdparty/boost/download.sh
+++ b/jjb/3rdparty/boost/download.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+cd $WORKSPACE/jjb/3rdparty/boost && wget --no-clobber https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.bz2

--- a/jjb/3rdparty/build_local.py
+++ b/jjb/3rdparty/build_local.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import sys
+import os
+import shutil
+import subprocess
+import glob
+import collections
+
+PACKAGES = collections.OrderedDict([('boost', []),
+                                    ('tbb', []),
+                                    ('ilmbase', []),
+                                    ('pyilmbase', ['boost', 'ilmbase']),
+                                    ('openexr', ['ilmbase'])])
+
+PACKAGE_FILES = {}
+
+def main(args):
+    curdir = os.path.abspath(os.curdir)
+    workspace = os.path.dirname(os.path.dirname(curdir))
+
+    print('Building all in workspace %s'%workspace)
+    os.environ['WORKSPACE'] = workspace
+    
+    print('Downloading...')
+    for pkg in PACKAGES.keys():
+        subprocess.check_call('%s/download.sh'%pkg)
+
+    for pkg, deps in PACKAGES.iteritems():
+        print('Building %s...'%pkg)
+        for dep in deps:
+            dst = os.path.join(pkg, os.path.basename(PACKAGE_FILES[dep]))
+            if not os.path.exists(dst):
+                print('Copying {} -> {}'.format(PACKAGE_FILES[dep], dst))
+                shutil.copyfile(PACKAGE_FILES[dep], dst)
+        cwd = os.path.join(curdir, pkg)
+        subprocess.check_call('docker build -t {pkg}-builder .'.format(pkg=pkg), cwd=cwd, shell=True)
+        subprocess.check_call('docker run --name {pkg}-builder --rm -v {cwd}:/mnt/dist {pkg}-builder'.format(pkg=pkg, cwd=cwd), cwd=cwd, shell=True)
+        pkgFile = glob.glob('%s/%s*vfx-2018.tar.bz2'%(pkg, pkg))[0]
+        print('Built artifact: {}'.format(pkgFile))
+        PACKAGE_FILES[pkg] = pkgFile
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/jjb/3rdparty/build_local.py
+++ b/jjb/3rdparty/build_local.py
@@ -11,6 +11,7 @@ PACKAGES = collections.OrderedDict([('boost', []),
                                     ('ilmbase', []),
                                     ('pyilmbase', ['boost', 'ilmbase']),
                                     ('openexr', ['ilmbase'])])
+PACKAGES['all'] = PACKAGES.keys()
 
 PACKAGE_FILES = {}
 

--- a/jjb/3rdparty/ilmbase/Dockerfile
+++ b/jjb/3rdparty/ilmbase/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+ENV ASWF_BUILD_DIR /tmp/vfx-build
+ENV ASWF_ROOT_DIR /opt/aswf/vfx2018
+
+USER root
+
+RUN mkdir -p $ASWF_BUILD_DIR && \
+    mkdir -p $ASWF_ROOT_DIR
+
+# Common requirements
+RUN yum install -y make bzip2
+
+ADD ilmbase-2.2.0.tar.gz $ASWF_BUILD_DIR
+
+WORKDIR $ASWF_BUILD_DIR/ilmbase-2.2.0
+RUN ./configure --prefix=$ASWF_ROOT_DIR/ilmbase
+RUN make
+RUN make install
+
+# Generating the tarball as part of running the image.
+# Needs "-v `pwd`:/mnt/dist" while running
+WORKDIR $ASWF_ROOT_DIR
+ENTRYPOINT tar -cvjSf /mnt/dist/ilmbase-2.2.0-vfx-2018.tar.bz2 ilmbase

--- a/jjb/3rdparty/ilmbase/download.sh
+++ b/jjb/3rdparty/ilmbase/download.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+cd $WORKSPACE/jjb/3rdparty/ilmbase && wget --no-clobber http://download.savannah.nongnu.org/releases/openexr/ilmbase-2.2.0.tar.gz

--- a/jjb/3rdparty/openexr/Dockerfile
+++ b/jjb/3rdparty/openexr/Dockerfile
@@ -1,0 +1,34 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+ENV ASWF_BUILD_DIR /tmp/vfx-build
+ENV ASWF_ROOT_DIR /opt/aswf/vfx2018
+
+USER root
+
+RUN mkdir -p $ASWF_BUILD_DIR && \
+    mkdir -p $ASWF_ROOT_DIR
+
+# Common requirements
+RUN yum install -y make bzip2 file
+
+ADD openexr-2.2.0.tar.gz $ASWF_BUILD_DIR
+
+ADD ilmbase-2.2.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ENV PKG_CONFIG_PATH $ASWF_ROOT_DIR/ilmbase/lib/pkgconfig
+ENV LD_LIBRARY_PATH $ASWF_ROOT_DIR/ilmbase/lib
+
+# OpenEXR requirements
+RUN yum install -y which zlib-devel
+
+WORKDIR $ASWF_BUILD_DIR/openexr-2.2.0
+
+RUN ./configure --prefix=$ASWF_ROOT_DIR/openexr
+
+RUN make
+
+RUN make install
+
+# Generating the tarball as part of running the image.
+# Needs "-v `pwd`:/mnt/dist" while running
+WORKDIR $ASWF_ROOT_DIR
+ENTRYPOINT tar -cvjSf /mnt/dist/openexr-2.2.0-vfx-2018.tar.bz2 openexr

--- a/jjb/3rdparty/openexr/download.sh
+++ b/jjb/3rdparty/openexr/download.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+cd $WORKSPACE/jjb/3rdparty/openexr && wget --no-clobber http://download.savannah.nongnu.org/releases/openexr/openexr-2.2.0.tar.gz

--- a/jjb/3rdparty/pyilmbase/Dockerfile
+++ b/jjb/3rdparty/pyilmbase/Dockerfile
@@ -1,0 +1,41 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+ENV ASWF_BUILD_DIR /tmp/vfx-build
+ENV ASWF_ROOT_DIR /opt/aswf/vfx2018
+
+USER root
+
+RUN mkdir -p $ASWF_BUILD_DIR && \
+    mkdir -p $ASWF_ROOT_DIR
+
+# Common requirements
+RUN yum install -y which make bzip2
+
+# pyilmbase build requirements
+RUN yum install -y file python-devel zlib-devel
+
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py" &&\
+    python get-pip.py &&\
+    pip install numpy==1.12.1
+
+ADD pyilmbase-2.2.0.tar.gz $ASWF_BUILD_DIR
+
+# ilmbase and boost dependencies
+ADD ilmbase-2.2.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ADD boost-1.61.0-vfx-2018.tar.bz2 $ASWF_ROOT_DIR
+ENV PKG_CONFIG_PATH $ASWF_ROOT_DIR/ilmbase/lib/pkgconfig
+ENV LD_LIBRARY_PATH $ASWF_ROOT_DIR/ilmbase/lib:$ASWF_ROOT_DIR/boost/lib
+
+WORKDIR $ASWF_BUILD_DIR/pyilmbase-2.2.0
+RUN ./configure \
+        --prefix=$ASWF_ROOT_DIR/pyilmbase \
+        --with-boost-include-dir=$ASWF_ROOT_DIR/boost/include \
+        --with-boost-lib-dir=$ASWF_ROOT_DIR/boost/lib
+
+RUN make
+RUN make install
+
+# Generating the tarball as part of running the image.
+# Needs "-v `pwd`:/mnt/dist" while running
+WORKDIR $ASWF_ROOT_DIR
+ENTRYPOINT tar -cvjSf /mnt/dist/pyilmbase-2.2.0-vfx-2018.tar.bz2 pyilmbase

--- a/jjb/3rdparty/pyilmbase/download.sh
+++ b/jjb/3rdparty/pyilmbase/download.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+cd $WORKSPACE/jjb/3rdparty/pyilmbase && wget --no-clobber http://download.savannah.nongnu.org/releases/openexr/pyilmbase-2.2.0.tar.gz

--- a/jjb/3rdparty/tbb/Dockerfile
+++ b/jjb/3rdparty/tbb/Dockerfile
@@ -1,0 +1,30 @@
+FROM centos/devtoolset-6-toolchain-centos7
+
+ENV ASWF_DIR /opt/aswf/vfx2018
+ENV TMP_DIR /tmp/vfx-build
+ENV DOWNLOADS_DIR /tmp/vfx-downloads
+
+USER root
+
+RUN mkdir -p $TMP_DIR && \
+    mkdir -p $ASWF_DIR && \
+    mkdir -p $DOWNLOADS_DIR
+
+RUN yum install -y wget make
+
+RUN wget https://github.com/01org/tbb/archive/2017_U6.tar.gz -O $DOWNLOADS_DIR/tbb_2017_U6.tar.gz
+
+RUN cd $TMP_DIR &&\
+    tar xf $DOWNLOADS_DIR/tbb_2017_U6.tar.gz &&\
+    cd $TMP_DIR/tbb-2017_U6 &&\
+    mkdir -p $ASWF_DIR/include && cp -R include/* $ASWF_DIR/include/ &&\
+    make && \
+    mkdir -p $ASWF_DIR/lib && cp build/*_release/*.so* $ASWF_DIR/lib &&\
+    make clean && \
+    make tbb_cpf=1 && \
+    mkdir -p $ASWF_DIR/lib && cp build/*_release/*.so* $ASWF_DIR/lib
+
+# Generating the tarball as part of running the image.
+# Needs "-v `pwd`:/mnt/dist" while running
+ENTRYPOINT cd $ASWF_DIR &&\
+    tar -cvjSf /mnt/dist/tbb-2017.6-vfx-2018.tar.bz2 *

--- a/jjb/3rdparty/tbb/Dockerfile
+++ b/jjb/3rdparty/tbb/Dockerfile
@@ -1,30 +1,35 @@
 FROM centos/devtoolset-6-toolchain-centos7
 
-ENV ASWF_DIR /opt/aswf/vfx2018
-ENV TMP_DIR /tmp/vfx-build
-ENV DOWNLOADS_DIR /tmp/vfx-downloads
+ENV ASWF_BUILD_DIR /tmp/vfx-build
+ENV ASWF_ROOT_DIR /opt/aswf/vfx2018
 
 USER root
 
-RUN mkdir -p $TMP_DIR && \
-    mkdir -p $ASWF_DIR && \
-    mkdir -p $DOWNLOADS_DIR
+RUN mkdir -p $ASWF_BUILD_DIR && \
+    mkdir -p $ASWF_ROOT_DIR
 
-RUN yum install -y wget make
+# Common requirements
+RUN yum install -y make bzip2
 
-RUN wget https://github.com/01org/tbb/archive/2017_U6.tar.gz -O $DOWNLOADS_DIR/tbb_2017_U6.tar.gz
+ADD 2017_U6.tar.gz $ASWF_BUILD_DIR
 
-RUN cd $TMP_DIR &&\
-    tar xf $DOWNLOADS_DIR/tbb_2017_U6.tar.gz &&\
-    cd $TMP_DIR/tbb-2017_U6 &&\
-    mkdir -p $ASWF_DIR/include && cp -R include/* $ASWF_DIR/include/ &&\
-    make && \
-    mkdir -p $ASWF_DIR/lib && cp build/*_release/*.so* $ASWF_DIR/lib &&\
-    make clean && \
+WORKDIR $ASWF_BUILD_DIR/tbb-2017_U6
+
+# Prepare install
+RUN mkdir -p $ASWF_ROOT_DIR/tbb/include &&\
+    mkdir -p $ASWF_ROOT_DIR/tbb/lib &&\
+    cp -R include/* $ASWF_ROOT_DIR/tbb/include/
+
+# Normal build
+RUN make && \
+    cp build/*_release/*.so* $ASWF_ROOT_DIR/tbb/lib
+
+# Community Preview Library with a clean first
+RUN make clean && \
     make tbb_cpf=1 && \
-    mkdir -p $ASWF_DIR/lib && cp build/*_release/*.so* $ASWF_DIR/lib
+    cp build/*_release/*.so* $ASWF_ROOT_DIR/tbb/lib
 
 # Generating the tarball as part of running the image.
 # Needs "-v `pwd`:/mnt/dist" while running
-ENTRYPOINT cd $ASWF_DIR &&\
-    tar -cvjSf /mnt/dist/tbb-2017.6-vfx-2018.tar.bz2 *
+WORKDIR $ASWF_ROOT_DIR
+ENTRYPOINT tar -cvjSf /mnt/dist/tbb-2017.6-vfx-2018.tar.bz2 tbb

--- a/jjb/3rdparty/tbb/download.sh
+++ b/jjb/3rdparty/tbb/download.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+cd $WORKSPACE/jjb/3rdparty/tbb && wget --no-clobber https://github.com/01org/tbb/archive/2017_U6.tar.gz


### PR DESCRIPTION
This PR introduces new 3rdparty jenkins jobs that build binaries of the VFX Platform packages on linux.
So far, here is a list of jobs and their inter-dependencies:
```
[('boost', []),
 ('tbb', []),
 ('ilmbase', []),
 ('pyilmbase', ['boost', 'ilmbase']),
 ('openexr', ['ilmbase'])
]
```
For now the jobs are not uploading their artifacts to nexus, so building `pyilmbase` and `openexr` will fail on the jenkins platform.
A new `build_local.py` script allows running the whole chain of builds on a single machine with docker installed, binaries are pretty much guaranteed to be identical as the ones built by jenkins.