### PR TITLE
Disable openvdb-cmake-verify

### DIFF
--- a/jjb/openvdb/openvdb.yaml
+++ b/jjb/openvdb/openvdb.yaml
@@ -2,7 +2,8 @@
 - project:
     name: openvdb
     jobs:
-      - 'github-cmake-verify'
+      - 'github-cmake-verify':
+          disable-job: true
       - 'openvdb-cmake-stage'
 
     stream: master


### PR DESCRIPTION
Per RT#70780 the cmake verify is presently failing and at present the
desire is to use circle-ci over Jenkins.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>